### PR TITLE
Fix marshalling bug

### DIFF
--- a/momento-provider/src/test/java/com/google/code/ssm/providers/momento/TestPOC.java
+++ b/momento-provider/src/test/java/com/google/code/ssm/providers/momento/TestPOC.java
@@ -1,6 +1,5 @@
 package com.google.code.ssm.providers.momento;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.code.ssm.Cache;
 import com.google.code.ssm.CacheFactory;
@@ -27,7 +26,7 @@ import java.io.Serializable;
 @ContextConfiguration(loader= AnnotationConfigContextLoader.class)
 public class TestPOC {
 
-    private static final String MOMENTO_AUTH_TOKEN = "<YOUR MOMENTO TOKEN GOES HERE>";
+    private static final String MOMENTO_AUTH_TOKEN = System.getenv("MOMENTO_AUTH_TOKEN");
     // IMPORTANT: This presumes you have already created a cache in Momento named 'example-cache'
     private static final String MOMENTO_CACHE_NAME = "example-cache";
 
@@ -58,6 +57,15 @@ public class TestPOC {
     public static class TestObject implements Serializable {
         int id;
         String name;
+        SubObject subObject;
+
+    }
+
+    @Data
+    @JsonSerialize
+    public static class SubObject implements Serializable {
+       String customerId;
+       String customerName;
     }
 
 
@@ -80,13 +88,8 @@ public class TestPOC {
     @SneakyThrows
     public TestObject getComplexObject(@ParameterValueKeyProvider String objectKey) {
         Cache cache = exampleCacheFactory.getObject();
-        ObjectMapper mapper = new ObjectMapper();
         if (cache != null) {
-            String result = cache.get(objectKey, SerializationType.PROVIDER);
-            if (result != null) {
-                TestObject obj = mapper.readValue(result, TestObject.class);
-                return obj;
-            }
+            return cache.get(objectKey, SerializationType.PROVIDER);
         }
         // Otherwise, retrieve object from source location, e.g. DynamoDB, S3
         // return getObjectFromSource(objectKey);


### PR DESCRIPTION
Fixes https://github.com/momentohq/simple-spring-memcached/issues/8

See above issue for some more details. I dug through the ElastiCache and Spymemcached source code and ultimately found what was missing. When we are serializing the data in an SSM-specific way we are prepending the bytes with an `int` flag the determines how the data was encoded by our provided transcoder.

When attempting to decode the data back, we were incorrectly passing the wrong the flag parameter, causing deserialization issues that customers reported.

I copied over the bit-masking code used to extract the flag header and updated our `get` path to decode the bytes that way.

To verify this, I updated our unit tests to include another POJO object within our `TestObject` just to make sure it could properly serialize:

```
    @Test
    @SneakyThrows
//    @Ignore // Comment out if you'd like to test this out yourself
    public void testPocComplex() {
        SubObject subObject = new SubObject();
        subObject.setCustomerId("abc123");
        subObject.setCustomerName("alice");
        TestObject t = new TestObject();
        t.setName("fooBar");
        t.setId(1);
        t.setSubObject(subObject);
        exampleCacheFactory.getCache().set("test-complex-key", 3000, t, SerializationType.PROVIDER);
        TestObject result = getComplexObject("test-complex-key");
        if (result == null) {
            System.out.println("Nothing found");
        } else {
            System.out.println("Got " + result);
        }
    }
```

Ran `mvn clean install`:

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.google.code.ssm.providers.momento.CachedObjectWrapperTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec - in com.google.code.ssm.providers.momento.CachedObjectWrapperTest
Running com.google.code.ssm.providers.momento.MomentoCacheConfigurationTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.535 sec - in com.google.code.ssm.providers.momento.MomentoCacheConfigurationTest
Running com.google.code.ssm.providers.momento.TestPOC
Got TestPOC.TestObject(id=1, name=fooBar, subObject=TestPOC.SubObject(customerId=abc123, customerName=alice))
Tests run: 2, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 3.24 sec - in com.google.code.ssm.providers.momento.TestPOC

Results :




Tests run: 5, Failures: 0, Errors: 0, Skipped: 1
```

This was targeting JDK 1.8 w/Java 8:

```
Tylers-MacBook-Pro :: ~/repo/simple-spring-memcached ‹fix-marshalling› » java -version                                                                                                                                   
openjdk version "1.8.0_322"
OpenJDK Runtime Environment (Zulu 8.60.0.21-CA-macosx) (build 1.8.0_322-b06)
OpenJDK 64-Bit Server VM (Zulu 8.60.0.21-CA-macosx) (build 25.322-b06, mixed mode)
Tylers-MacBook-Pro :: ~/repo/simple-spring-memcached ‹fix-marshalling› »
```