### PR TITLE
Fix issue causing deserialization to constantly fail

### DIFF
--- a/momento-provider/src/main/java/com/google/code/ssm/providers/momento/MomentoCacheClientFactory.java
+++ b/momento-provider/src/main/java/com/google/code/ssm/providers/momento/MomentoCacheClientFactory.java
@@ -21,6 +21,7 @@ import java.net.InetSocketAddress;
 import java.util.List;
 
 import momento.sdk.SimpleCacheClient;
+import momento.sdk.SimpleCacheClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,10 +40,13 @@ public class MomentoCacheClientFactory implements CacheClientFactory {
             momentoConfiguration = (MomentoConfiguration) conf;
         }
         if (momentoConfiguration != null && momentoConfiguration.getMomentoAuthToken() != null) {
-            SimpleCacheClient client = SimpleCacheClient.builder(
+            SimpleCacheClientBuilder builder = SimpleCacheClient.builder(
                         momentoConfiguration.getMomentoAuthToken(),
-                        momentoConfiguration.getDefaultTtl())
-                    .build();
+                        momentoConfiguration.getDefaultTtl());
+            if (momentoConfiguration.getRequestTimeout().isPresent()) {
+                builder.requestTimeout(momentoConfiguration.getRequestTimeout().get());
+            }
+            SimpleCacheClient client = builder.build();
             return new MomentoClientWrapper(client, momentoConfiguration.getCacheName());
         }
         throw new RuntimeException("Momento auth token must be provided in CacheConfiguration");

--- a/momento-provider/src/main/java/com/google/code/ssm/providers/momento/MomentoClientWrapper.java
+++ b/momento-provider/src/main/java/com/google/code/ssm/providers/momento/MomentoClientWrapper.java
@@ -234,7 +234,9 @@ class MomentoClientWrapper extends AbstractMemcacheClientWrapper {
         if (cacheGetResponse.isPresent()) {
             ByteBuffer byteBuffer = ByteBuffer.wrap(cacheGetResponse.get());
             int flags = byteBuffer.getInt();
-            byte[] originalData = byteBuffer.array();
+            // Ensure we perform a deep copy of the remaining bytes into a separate byte array
+            byte[] originalData = new byte[byteBuffer.remaining()];
+            byteBuffer.get(originalData);
             return Optional.of(new CachedData(flags, originalData, originalData.length));
         }
         return Optional.empty();

--- a/momento-provider/src/main/java/com/google/code/ssm/providers/momento/MomentoConfiguration.java
+++ b/momento-provider/src/main/java/com/google/code/ssm/providers/momento/MomentoConfiguration.java
@@ -24,6 +24,9 @@ import net.spy.memcached.transcoders.Transcoder;
 
 import com.google.code.ssm.providers.CacheConfiguration;
 
+import java.time.Duration;
+import java.util.Optional;
+
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -31,6 +34,7 @@ public class MomentoConfiguration extends CacheConfiguration {
     private String momentoAuthToken;
     private String cacheName;
     private int defaultTtl = 300;
+    private Optional<Duration> requestTimeout = Optional.empty();
 
     /**
      * default transcoder or null if not set

--- a/momento-provider/src/test/java/com/google/code/ssm/providers/momento/TestPOC.java
+++ b/momento-provider/src/test/java/com/google/code/ssm/providers/momento/TestPOC.java
@@ -68,7 +68,6 @@ public class TestPOC {
        String customerName;
     }
 
-
     @ReadThroughSingleCache(namespace = "TestString", expiration = 3600)
     @SneakyThrows
     public String getSimpleObject(@ParameterValueKeyProvider String complexObjectPk) {
@@ -95,7 +94,6 @@ public class TestPOC {
         // return getObjectFromSource(objectKey);
         return null;
     }
-
 
     @Test
     @SneakyThrows

--- a/momento-provider/src/test/java/com/google/code/ssm/providers/momento/TestPOC.java
+++ b/momento-provider/src/test/java/com/google/code/ssm/providers/momento/TestPOC.java
@@ -7,6 +7,7 @@ import com.google.code.ssm.api.ParameterValueKeyProvider;
 import com.google.code.ssm.api.ReadThroughSingleCache;
 import com.google.code.ssm.api.format.SerializationType;
 import com.google.code.ssm.config.AbstractSSMConfiguration;
+import com.google.code.ssm.providers.CacheException;
 import lombok.Data;
 import lombok.SneakyThrows;
 import org.junit.Ignore;
@@ -20,6 +21,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 import java.io.Serializable;
+import java.util.concurrent.TimeoutException;
 
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -97,7 +99,7 @@ public class TestPOC {
 
     @Test
     @SneakyThrows
-    @Ignore // Comment out if you'd like to test this out yourself
+//    @Ignore // Comment out if you'd like to test this out yourself
     public void testPocSimple() {
         String result = getSimpleObject("test-key");
         if (result == null) {
@@ -111,11 +113,26 @@ public class TestPOC {
     @SneakyThrows
     @Ignore // Comment out if you'd like to test this out yourself
     public void testPocComplex() {
+        // Uncomment if you want to verify objects are de/serialized properly
+        // putTestObjectInCache();
         TestObject result = getComplexObject("test-complex-key");
         if (result == null) {
             System.out.println("Nothing found");
         } else {
             System.out.println("Got " + result);
         }
+    }
+
+    // This can only be used if you have a valid MOMENTO_AUTH_TOKEN in your environment
+    // along with a cache created named "example-cache"
+    private void putTestObjectInCache() throws CacheException, TimeoutException {
+        SubObject subObject = new SubObject();
+        subObject.setCustomerId("abc123");
+        subObject.setCustomerName("customerName");
+        TestObject testObject = new TestObject();
+        testObject.setName("testObjectName");
+        testObject.setId(42);
+        testObject.setSubObject(subObject);
+        exampleCacheFactory.getCache().set("test-complex-key", 30, testObject, SerializationType.PROVIDER);
     }
 }


### PR DESCRIPTION
When we are de/serializing data, we wrap the data in a `CachedObject` (or `CachedData`). This object stores two things:
1. The `flags` (stored as a raw `int`) that denote _how_ we serialized the data
2. The raw data stored in a `byte[]`

When we are _reading_, we are presuming the first four bytes (an `int`) contain the flags and the rest of the bytes are the desired data that we will use to deserialize back into our desired `Object`. However, when _writing_ we have never been persisting the `flags` we used.

This PR updates the behavior of the client to concatenate the bytes of data into one byte array (written out as `flags|data`) before sending it to Momento. That way when we read back we can now correctly grab the `flags` we used. This should fix all of our de/serialization woes.

I've also added the ability for customers to add a `requestTimeout` parameter to the configuration if they'd like our deadlines to be longer/shorter than the SDK's default.

I tested this by writing (but not committing) a bunch of tests in the `TestPOC` unit test class that operated with a bunch of different types of data. All passed
