### PR TITLE
fix: release version 4.2.16-SNAPSHOT using JDK 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you are using maven, you can try it now:
        <dependency>
          <groupId>software.momento.java.spring</groupId>
          <artifactId>xmemcached-provider</artifactId>
-         <version>4.2.15-SNAPSHOT</version>
+         <version>4.2.16-SNAPSHOT</version>
        </dependency> 
     </dependencies>
 

--- a/README_publish.md
+++ b/README_publish.md
@@ -3,12 +3,12 @@
 To publish to the sonatype central snapshot repo, you will need to get your encrypted password
 from sonatype.
 
-You will need to publish using JDK 11, not JDK 17.  Also, there are
+**IMPORTANT**: You will need to publish using JDK 8, not JDK 11 or 17.  Also, there are
 some failing int tests at the time of this writing so you may need to
 skip the tests.  e.g.:
 
 ```
-sdk use java 11.0.11.hs-adpt
+sdk use java 8.0.402-amzn
 mvn deploy -DskipTests
 ```
 

--- a/aws-elasticache-provider/pom.xml
+++ b/aws-elasticache-provider/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>software.momento.java.spring</groupId>
 		<artifactId>simple-spring-memcached-parent</artifactId>
-		<version>4.2.15-SNAPSHOT</version>
+		<version>4.2.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>aws-elasticache-provider</artifactId>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>software.momento.java.spring</groupId>
 		<artifactId>simple-spring-memcached-parent</artifactId>
-		<version>4.2.15-SNAPSHOT</version>
+		<version>4.2.16-SNAPSHOT</version>
 	</parent>
 	<artifactId>integration-test</artifactId>
 	<packaging>jar</packaging>

--- a/jmemcached-maven-plugin/pom.xml
+++ b/jmemcached-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>software.momento.java.spring</groupId>
 		<artifactId>simple-spring-memcached-parent</artifactId>
-		<version>4.2.15-SNAPSHOT</version>
+		<version>4.2.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>jmemcached-maven-plugin</artifactId>

--- a/momento-provider/pom.xml
+++ b/momento-provider/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>software.momento.java.spring</groupId>
         <artifactId>simple-spring-memcached-parent</artifactId>
-        <version>4.2.15-SNAPSHOT</version>
+        <version>4.2.16-SNAPSHOT</version>
     </parent>
 
     <artifactId>momento-provider</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>software.momento.java.spring</groupId>
     <artifactId>simple-spring-memcached-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.2.15-SNAPSHOT</version>
+    <version>4.2.16-SNAPSHOT</version>
     <name>simple-spring-memcached-parent</name>
     <description>Simple spring memcached - parent</description>
     <url>http://github.com/momentohq/simple-spring-memcached</url>

--- a/simple-spring-memcached/pom.xml
+++ b/simple-spring-memcached/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>software.momento.java.spring</groupId>
 		<artifactId>simple-spring-memcached-parent</artifactId>
-		<version>4.2.15-SNAPSHOT</version>
+		<version>4.2.16-SNAPSHOT</version>
 	</parent>
 	<artifactId>simple-spring-memcached</artifactId>
 	<packaging>jar</packaging>

--- a/spring-cache-integration-test/pom.xml
+++ b/spring-cache-integration-test/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>software.momento.java.spring</groupId>
 		<artifactId>simple-spring-memcached-parent</artifactId>
-		<version>4.2.15-SNAPSHOT</version>
+		<version>4.2.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-cache-integration-test</artifactId>

--- a/spring-cache/pom.xml
+++ b/spring-cache/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>software.momento.java.spring</groupId>
 		<artifactId>simple-spring-memcached-parent</artifactId>
-		<version>4.2.15-SNAPSHOT</version>
+		<version>4.2.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spring-cache</artifactId>

--- a/spymemcached-provider/pom.xml
+++ b/spymemcached-provider/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>software.momento.java.spring</groupId>
 		<artifactId>simple-spring-memcached-parent</artifactId>
-		<version>4.2.15-SNAPSHOT</version>
+		<version>4.2.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>spymemcached-provider</artifactId>

--- a/xmemcached-provider/pom.xml
+++ b/xmemcached-provider/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>software.momento.java.spring</groupId>
 		<artifactId>simple-spring-memcached-parent</artifactId>
-		<version>4.2.15-SNAPSHOT</version>
+		<version>4.2.16-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>xmemcached-provider</artifactId>


### PR DESCRIPTION
The previous release was done using JDK 11, which uses some
ByteBuffer APIs that are not backward compatible with JDK 8.
This commit bumps the version number for a new release
and updates the publishing instructions to clarify that
it needs to be released using JDK 8.
